### PR TITLE
案件5　修正

### DIFF
--- a/WebContent/js/script.js
+++ b/WebContent/js/script.js
@@ -242,6 +242,14 @@ $('#addImg').on('change',function(e){
 	fileReader.readAsDataURL(e.target.files[0]);
 });
 
+$('#updateImg').on('change',function(e){
+	let fileReader = new FileReader();
+	fileReader.onload = function(e){
+		$('.imgPreview').show();
+		$('#updateImgPreview').attr('src', e.target.result);
+	}
+	fileReader.readAsDataURL(e.target.files[0]);
+});
 
 /*=================確認画面ポップアップ======================*/
 

--- a/WebContent/views/product-info.jsp
+++ b/WebContent/views/product-info.jsp
@@ -36,41 +36,69 @@
 
 <main>
 
-<h2>商品情報管理</h2>
+	<h1>商品情報管理</h1>
 
-<div class="product-list">	
-	<div class="productList-img">		
-		<img src="${'/ShoppingSite/img/item/'.concat(product.getImgURL())}" height="120px" width="auto">
-	</div>
-	<p class="manga-title">${manga.getTitle()} (${product.getNumber()})</p>
-	<p class="product-price"><span class="price"><span class="yen">￥</span>${product.getPrice()}</span></p>
-	<p class="description">${product.getDescription()}</p>
-</div>
+	<a href="/ShoppingSite/views/product-management.jsp">&lt;&lt;商品一覧に戻る</a>
 
-<form method="post" id="product-info-form">
-	<input type="hidden" name="productId" value="<c:if test="${product.getProductId() != null}">${product.getProductId()}</c:if>">
-	
-	<p>巻数</p>
-	<input type="number" name="number" class="form-text number-form" value="<c:if test="${product.getNumber() != null}">${product.getNumber()}</c:if>" min="0" max="999" required>
-	
-	<p>価格</p>
-	<input type="number" name="price" class="form-text price-form" value="<c:if test="${product.getPrice() != null}">${product.getPrice()}</c:if>" min="0" required>
-	
-	<p>作品情報</p>
-	<textarea name="description" rows="5" cols="75" class="form-textarea">${product.getDescription()}</textarea>
-	
-	<p><c:if test="${productManagementMessage != null}">${productManagementMessage}</c:if></p>
-	
-	<div class="div-btn">
-		<input type="button" value="削除" id="product-delete-btn" class="medium-btn reverse-btn">
-		<input type="button" value="更新" id="product-update-btn" class="medium-btn">
+	<div class="product-list">
+		<div class="productList-img">
+			<img src="${'/ShoppingSite/img/item/'.concat(product.getImgURL())}"
+				height="120px" width="auto">
+		</div>
+		<p class="manga-title">${manga.getTitle()}
+			(${product.getNumber()})</p>
+		<p class="product-price">
+			<span class="price"><span class="yen">￥</span>${product.getPrice()}</span>
+		</p>
+		<p class="description">${product.getDescription()}</p>
 	</div>
-</form>
+
+	<form method="post" id="product-info-form" class="product-form" enctype="multipart/form-data">
+		<input type="hidden" name="productId"
+			value="<c:if test="${product.getProductId() != null}">${product.getProductId()}</c:if>">
+
+		<div class="div-number">
+			<p>巻数</p>
+			<input type="number" name="number" class="form-text number-form"
+				value="<c:if test="${product.getNumber() != null}">${product.getNumber()}</c:if>"
+				min="0" max="999" required>
+		</div>
+		<div class="div-price">
+			<p>価格</p>
+			<input type="number" name="price" class="form-text price-form"
+				value="<c:if test="${product.getPrice() != null}">${product.getPrice()}</c:if>"
+				min="0" required>
+		</div>
+		<div class="div-description">
+			<p>作品情報</p>
+			<textarea name="description" rows="6" cols="75" class="form-textarea"
+				required>${product.getDescription()}</textarea>
+		</div>
+		<div class="div-file">
+			<p>商品画像アップロード</p>
+			<input type="file" name="img" id="updateImg" class="form-file" accept="imaga/*">
+
+			<figure class="imgPreview">
+				<img src="${'/ShoppingSite/img/item/'.concat(product.getImgURL())}" id="updateImgPreview">
+				<figcaption>${product.getImgURL()}</figcaption>
+			</figure>
+		</div>
+		<div class="div-message">
+			<p>
+				<c:if test="${productManagementMessage != null}">${productManagementMessage}</c:if>
+			</p>
+
+			<div class="div-btn">
+				<input type="button" value="削除" id="product-delete-btn" class="medium-btn reverse-btn"> 
+				<input type="button" value="更新" id="product-update-btn" class="medium-btn">
+			</div>
+		</div>
+	</form>
 </main>
-<% 
-	session.removeAttribute("manga");
-	session.removeAttribute("product");
-	session.removeAttribute("productManagementMessage"); 
+<%
+session.removeAttribute("manga");
+session.removeAttribute("product");
+session.removeAttribute("productManagementMessage");
 %>
 
 

--- a/src/main/java/jp/co/aforce/dao/MangaDAO.java
+++ b/src/main/java/jp/co/aforce/dao/MangaDAO.java
@@ -243,6 +243,21 @@ public class MangaDAO extends DAO{
 		return line;
 	}
 	
+	public int update04(String mangaId, String imgURL) throws Exception {
+		Connection con = getConnection();
+
+		PreparedStatement st = con.prepareStatement("UPDATE manga_info SET "
+				+ "IMG_URL = ? WHERE MANGA_ID = ?");
+		st.setString(1, imgURL);
+		st.setString(2, mangaId);
+		int line = st.executeUpdate();
+
+		st.close();
+		con.close();
+		
+		return line;
+	}
+	
 	public int delete01(String mangaId) throws Exception {
 		Connection con = getConnection();
 

--- a/src/main/java/jp/co/aforce/dao/ProductDAO.java
+++ b/src/main/java/jp/co/aforce/dao/ProductDAO.java
@@ -74,7 +74,27 @@ public Product search02(String productId) throws Exception {
 		return list;
 	}
 	
-	
+	public String search04(String mangaId) throws Exception {
+		Connection con = getConnection();
+		
+		PreparedStatement st = con.prepareStatement("SELECT IMG_URL "
+				+ "FROM product_info t1 "
+				+ "LEFT OUTER JOIN (SELECT MANGA_ID, MAX(NUMBER) AS 'MAX' FROM product_info GROUP BY MANGA_ID) t2 "
+				+ "ON t1.MANGA_ID = t2.MANGA_ID "
+				+ "WHERE t1.NUMBER = t2.MAX "
+				+ "AND t1.MANGA_ID = ?");
+		st.setString(1, mangaId);
+		ResultSet rs = st.executeQuery();
+		
+		rs.next();
+		
+		String imgURL = rs.getString("IMG_URL");
+		
+		st.close();
+		con.close();
+		
+		return imgURL;
+	}
 	
 	public int insert01(Product product) throws Exception{
 		
@@ -123,6 +143,26 @@ public Product search02(String productId) throws Exception {
 				+ "WHERE PRODUCT_ID = ?");
 		st.setString(1, productId);
 		st.setString(2, product.getProductId());
+		int line = st.executeUpdate();
+
+		st.close();
+		con.close();
+		
+		return line;
+	}
+	
+	public int update03(Product product) throws Exception {
+
+		Connection con = getConnection();
+
+		PreparedStatement st = con.prepareStatement("UPDATE product_info SET "
+				+ "NUMBER = ?, PRICE = ?, DESCRIPTION = ?, IMG_URL = ?"
+				+ "WHERE PRODUCT_ID = ?");
+		st.setInt(1, product.getNumber());
+		st.setInt(2, product.getPrice());
+		st.setString(3, product.getDescription());
+		st.setString(4, product.getImgURL());
+		st.setString(5, product.getProductId());
 		int line = st.executeUpdate();
 
 		st.close();

--- a/src/main/java/jp/co/aforce/servlet/ProductAdd.java
+++ b/src/main/java/jp/co/aforce/servlet/ProductAdd.java
@@ -71,8 +71,8 @@ public class ProductAdd extends HttpServlet {
 						part.write(path+File.separator+filename);
 						manga.raiseTotalNumber(); // 総巻数を増やす
 						mangaDAO.update02(manga);
-						manga.setImgURL(filename);
-						mangaDAO.update03(manga);
+						mangaDAO.update04(mangaId, productDAO.search04(mangaId));
+						manga.setImgURL(mangaDAO.search03(mangaId).getImgURL());
 						session.setAttribute("adminManga", manga);
 						String title = (String) session.getAttribute("adminSearchTitle");
 						List<Manga> mangaList = mangaDAO.search04(title); 

--- a/src/main/java/jp/co/aforce/servlet/ProductUpdate.java
+++ b/src/main/java/jp/co/aforce/servlet/ProductUpdate.java
@@ -1,20 +1,29 @@
 package jp.co.aforce.servlet;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
 
 import javax.servlet.ServletException;
+import javax.servlet.annotation.MultipartConfig;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
+import javax.servlet.http.Part;
 
+import jp.co.aforce.bean.Manga;
 import jp.co.aforce.bean.Product;
 import jp.co.aforce.constant.Constant.Message;
+import jp.co.aforce.dao.MangaDAO;
 import jp.co.aforce.dao.ProductDAO;
 
 
 @WebServlet("/servlet/product-update")
+@MultipartConfig
 public class ProductUpdate extends HttpServlet {
 	public void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
 		
@@ -23,28 +32,57 @@ public class ProductUpdate extends HttpServlet {
 		try {
 			String productId = request.getParameter("productId");
 			
+			ProductDAO productDAO = new ProductDAO();
+			
+			String imgURL = productDAO.search02(productId).getImgURL();
+			
 			Product product = new Product();
 			product.setProductId(productId);
 			product.setNumber(Integer.parseInt(request.getParameter("number")));
 			product.setPrice(Integer.parseInt(request.getParameter("price")));
 			product.setDescription(request.getParameter("description"));
 			
-			ProductDAO dao = new ProductDAO();
-			int line = dao.update01(product);
-			
+			Part part = request.getPart("img");
+			String filename = Paths.get(part.getSubmittedFileName()).getFileName().toString();
+			String path=getServletContext().getRealPath("/img/item");
+			int line;
+			if(filename.length() == 0) {
+				line = productDAO.update01(product);
+			}else {
+				product.setImgURL(filename);
+				line = productDAO.update03(product);
+			}
 			if(line != 1) {
 				session.setAttribute("mangaManagementMessage", Message.E_W0005);
 			}else {
-				product = dao.search02(productId);
+				if(filename.length() != 0) {
+					// 更新前の商品の画像ファイルをフォルダから削除
+					Files.delete(Paths.get(path+File.separator+imgURL));
+					
+					part.write(path+File.separator+filename);
+				}
+				product = productDAO.search02(productId);
 				String mangaId = product.getMangaId();
 				String number = String.valueOf(product.getNumber());
 				while(number.length() < 3) {
 					number = "0" + number;
 				}
 				String newProductId = mangaId + number;
-				dao.update02(product, newProductId);
-				session.setAttribute("adminProduct", dao.search02(newProductId));
+				productDAO.update02(product, newProductId);
+				
+				MangaDAO mangaDAO = new MangaDAO();
+				// 最新の単行本の画像をマンガタイトルの画像に変更
+				mangaDAO.update04(mangaId, productDAO.search04(mangaId));
+				session.setAttribute("adminManga", mangaDAO.search03(mangaId));
+				session.setAttribute("adminProduct", productDAO.search02(newProductId));
 				session.setAttribute("productManagementMessage", Message.I_W0005.replace("{0}",newProductId));
+				
+				// 表示するマンガタイトルリスト、商品リストを削除後の状態に更新
+				String title = (String) session.getAttribute("adminSearchTitle");
+				List<Manga> mangaList = mangaDAO.search04(title); 
+				List<Product> productList = productDAO.search03(product.getMangaId());
+				session.setAttribute("adminMangaList", mangaList);
+				session.setAttribute("adminProductList", productList);
 			}
 			response.sendRedirect("/ShoppingSite/views/product-info.jsp");
 		} catch (Exception e) {


### PR DESCRIPTION
@git-fuji-hub 
feature/5ブランチにて案件5に関する修正を行いました。

・script.js
　・商品情報管理画面②(product-info.jsp)にて、画像ファイル選択時に発生させる処理を追加[245-252行] 
・product-info.jsp
　・選択画像プレビューのためのfigureタグを追加 [81-84行]
　・選択画像プレビュー追加による商品情報入力フォームのデザイン変更 [56-96行]
　・formのenctype属性を”multipart/form-data”に変更（ファイル送信のため）[56行]
・MangaDAO.java
　・update04メソッドの追加（マンガIDをキーに画像URLを更新）[246-259行]
・ProductDAO.java
　・search04メソッドの追加（マンガIDをキーに巻数が一番大きい商品の画像URLを取得）[77-97行]
　・update03メソッドの追加（商品IDをキーに商品情報(画像URLを含む)を更新）[154-172行]
・ProductAdd.java
　・商品追加時、マンガタイトルの画像を「追加した商品の画像」に更新
　　　↓ 変更
　　商品追加時、マンガタイトルの画像を「巻数が最も大きいの商品(最新の商品)の画像」に更新　[74-75行]
・ProductDelete.java
　・@MultipartConfigアノテーションを追加（multipart/form-data形式のリクエストに対応するため）[25行]
　・商品追加時、マンガタイトルの画像を「巻数が最も大きいの商品(最新の商品)の画像」に更新する処理を追加　[48-50行]
　・削除した商品の画像ファイルをフォルダから削除する処理を追加　[52-54行]
・ProductUpdate.java
　・@MultipartConfigアノテーションを追加（multipart/form-data形式のリクエストに対応するため）[26行]
　・商品追加時、マンガタイトルの画像を「巻数が最も大きいの商品(最新の商品)の画像」に更新する処理を追加　[74-75行]
　・更新前の商品の画像ファイルをフォルダから削除する処理を追加　[59-60行]
　・「商品画像以外を更新」
　　　↓ 変更
　　画像ファイルが送信されていない場合は「商品画像以外の商品情報を更新」、画像ファイルが送信されている場合は「商品画像を含む商品情報を更新」　[48-54行]
　・商品の画像ファイルを送信された画像ファイルに更新する処理を追加　[45-47, 52-53, 62行]
　・表示するマンガタイトルリスト、商品リストを削除後の状態に更新する処理を追加 [80-85行]


ご確認のほどよろしくお願いいたします。