### PR TITLE
案件5　故障改修

### DIFF
--- a/WebContent/js/script.js
+++ b/WebContent/js/script.js
@@ -247,6 +247,7 @@ $('#updateImg').on('change',function(e){
 	fileReader.onload = function(e){
 		$('.imgPreview').show();
 		$('#updateImgPreview').attr('src', e.target.result);
+		$('#updateImgCaption').text($('#updateImg').prop('files')[0].name);
 	}
 	fileReader.readAsDataURL(e.target.files[0]);
 });

--- a/WebContent/views/product-info.jsp
+++ b/WebContent/views/product-info.jsp
@@ -60,19 +60,19 @@
 		<div class="div-number">
 			<p>巻数</p>
 			<input type="number" name="number" class="form-text number-form"
-				value="<c:if test="${product.getNumber() != null}">${product.getNumber()}</c:if>"
+				value="<c:choose><c:when test="${number != null}">${number}</c:when><c:otherwise>${product.getNumber()}</c:otherwise></c:choose>"
 				min="0" max="999" required>
 		</div>
 		<div class="div-price">
 			<p>価格</p>
 			<input type="number" name="price" class="form-text price-form"
-				value="<c:if test="${product.getPrice() != null}">${product.getPrice()}</c:if>"
+				value="<c:choose><c:when test="${price != null}">${price}</c:when><c:otherwise>${product.getPrice()}</c:otherwise></c:choose>"
 				min="0" required>
 		</div>
 		<div class="div-description">
 			<p>作品情報</p>
 			<textarea name="description" rows="6" cols="75" class="form-textarea"
-				required>${product.getDescription()}</textarea>
+				required><c:choose><c:when test="${description != null}">${description}</c:when><c:otherwise>${product.getDescription()}</c:otherwise></c:choose></textarea>
 		</div>
 		<div class="div-file">
 			<p>商品画像アップロード</p>
@@ -80,7 +80,7 @@
 
 			<figure class="imgPreview">
 				<img src="${'/ShoppingSite/img/item/'.concat(product.getImgURL())}" id="updateImgPreview">
-				<figcaption>${product.getImgURL()}</figcaption>
+				<figcaption id="updateImgCaption">${product.getImgURL()}</figcaption>
 			</figure>
 		</div>
 		<div class="div-message">
@@ -99,6 +99,9 @@
 session.removeAttribute("manga");
 session.removeAttribute("product");
 session.removeAttribute("productManagementMessage");
+session.removeAttribute("number");
+session.removeAttribute("price");
+session.removeAttribute("description");
 %>
 
 

--- a/src/main/java/jp/co/aforce/constant/Constant.java
+++ b/src/main/java/jp/co/aforce/constant/Constant.java
@@ -39,6 +39,7 @@ public class Constant {
 		public static final String W_C0005 = "この商品は既に追加されています。";
 		public static final String W_C0006 = "現在のパスワードが間違っています。";
 		public static final String W_C0007 = "新しいパスワードが一致していません";
+		public static final String W_C0008 = "このマンガタイトルの第{0}巻は既に存在します。";
 		public static final String E_W0001 = "会員情報登録に失敗しました。";
 		public static final String E_W0002 = "会員情報更新に失敗しました。";
 		public static final String E_W0003 = "会員情報削除に失敗しました。";

--- a/src/main/java/jp/co/aforce/dao/ProductDAO.java
+++ b/src/main/java/jp/co/aforce/dao/ProductDAO.java
@@ -96,6 +96,27 @@ public Product search02(String productId) throws Exception {
 		return imgURL;
 	}
 	
+	public int search05(String mangaId, int number) throws Exception {
+		Connection con = getConnection();
+		
+		PreparedStatement st = con.prepareStatement("SELECT COUNT(*) "
+				+ "FROM product_info "
+				+ "WHERE MANGA_ID = ? "
+				+ "AND NUMBER = ?");
+		st.setString(1, mangaId);
+		st.setInt(2, number);
+		ResultSet rs = st.executeQuery();
+		
+		rs.next();
+		
+		int count = rs.getInt("COUNT(*)");
+		
+		st.close();
+		con.close();
+		
+		return count;
+	}
+	
 	public int insert01(Product product) throws Exception{
 		
 		Connection con = getConnection();

--- a/src/main/java/jp/co/aforce/servlet/ProductDelete.java
+++ b/src/main/java/jp/co/aforce/servlet/ProductDelete.java
@@ -38,15 +38,19 @@ public class ProductDelete extends HttpServlet {
 			
 			int line = productDAO.delete01(productId); // 商品をデータベースから削除
 			if(line != 1) {
-				session.setAttribute("mangaManagementMessage", Message.E_W0006);
+				session.setAttribute("productManagementMessage", Message.E_W0009);
 			}else {
 				MangaDAO mangaDAO = new MangaDAO();
 				Manga manga = mangaDAO.search03(product.getMangaId());
 				manga.reduceTotalNumber(); // 総巻数を減らす
 				mangaDAO.update02(manga);
 				
-				// 最新の単行本の画像をマンガタイトルの画像に変更
-				mangaDAO.update04(mangaId, productDAO.search04(mangaId));
+				if(manga.getTotalNumber() == 0) {
+					mangaDAO.update04(mangaId, null);
+				}else {
+					// 最新の単行本の画像をマンガタイトルの画像に変更
+					mangaDAO.update04(mangaId, productDAO.search04(mangaId));
+				}
 				session.setAttribute("adminManga", mangaDAO.search03(mangaId));
 				
 				// 削除した商品の画像ファイルをフォルダから削除
@@ -60,7 +64,7 @@ public class ProductDelete extends HttpServlet {
 				session.setAttribute("adminMangaList", mangaList);
 				session.setAttribute("adminProductList", productList);
 			}
-			response.sendRedirect("/ShoppingSite/views/manga-management.jsp");
+			response.sendRedirect("/ShoppingSite/views/product-management.jsp");
 		}catch (Exception e) {
 			e.printStackTrace();
 		}

--- a/src/main/java/jp/co/aforce/servlet/ProductUpdate.java
+++ b/src/main/java/jp/co/aforce/servlet/ProductUpdate.java
@@ -34,6 +34,7 @@ public class ProductUpdate extends HttpServlet {
 			
 			ProductDAO productDAO = new ProductDAO();
 			
+			String mangaId = productDAO.search02(productId).getMangaId();
 			String imgURL = productDAO.search02(productId).getImgURL();
 			
 			Product product = new Product();
@@ -42,47 +43,56 @@ public class ProductUpdate extends HttpServlet {
 			product.setPrice(Integer.parseInt(request.getParameter("price")));
 			product.setDescription(request.getParameter("description"));
 			
-			Part part = request.getPart("img");
-			String filename = Paths.get(part.getSubmittedFileName()).getFileName().toString();
-			String path=getServletContext().getRealPath("/img/item");
-			int line;
-			if(filename.length() == 0) {
-				line = productDAO.update01(product);
-			}else {
-				product.setImgURL(filename);
-				line = productDAO.update03(product);
-			}
-			if(line != 1) {
-				session.setAttribute("mangaManagementMessage", Message.E_W0005);
-			}else {
-				if(filename.length() != 0) {
-					// 更新前の商品の画像ファイルをフォルダから削除
-					Files.delete(Paths.get(path+File.separator+imgURL));
-					
-					part.write(path+File.separator+filename);
-				}
-				product = productDAO.search02(productId);
-				String mangaId = product.getMangaId();
-				String number = String.valueOf(product.getNumber());
-				while(number.length() < 3) {
-					number = "0" + number;
-				}
-				String newProductId = mangaId + number;
-				productDAO.update02(product, newProductId);
+			if(product.getNumber() != productDAO.search02(productId).getNumber()
+				&&
+				productDAO.search05(mangaId, product.getNumber()) != 0) {	// 巻数が変わっているかつ商品があるかどうかチェック
+					session.setAttribute("number", product.getNumber());
+					session.setAttribute("price", product.getPrice());
+					session.setAttribute("description", product.getDescription());
+					session.setAttribute("productManagementMessage", Message.W_C0008.replace("{0}", ((Integer)product.getNumber()).toString()));
 				
-				MangaDAO mangaDAO = new MangaDAO();
-				// 最新の単行本の画像をマンガタイトルの画像に変更
-				mangaDAO.update04(mangaId, productDAO.search04(mangaId));
-				session.setAttribute("adminManga", mangaDAO.search03(mangaId));
-				session.setAttribute("adminProduct", productDAO.search02(newProductId));
-				session.setAttribute("productManagementMessage", Message.I_W0005.replace("{0}",newProductId));
-				
-				// 表示するマンガタイトルリスト、商品リストを削除後の状態に更新
-				String title = (String) session.getAttribute("adminSearchTitle");
-				List<Manga> mangaList = mangaDAO.search04(title); 
-				List<Product> productList = productDAO.search03(product.getMangaId());
-				session.setAttribute("adminMangaList", mangaList);
-				session.setAttribute("adminProductList", productList);
+			}else {
+				Part part = request.getPart("img");
+				String filename = Paths.get(part.getSubmittedFileName()).getFileName().toString();
+				String path=getServletContext().getRealPath("/img/item");
+				int line;
+				if(filename.length() == 0) {
+					line = productDAO.update01(product);
+				}else {
+					product.setImgURL(filename);
+					line = productDAO.update03(product);
+				}
+				if(line != 1) {
+					session.setAttribute("productManagementMessage", Message.E_W0008);
+				}else {
+					if(filename.length() != 0) {
+						// 更新前の商品の画像ファイルをフォルダから削除
+						Files.delete(Paths.get(path+File.separator+imgURL));
+
+						part.write(path+File.separator+filename);
+					}
+					product = productDAO.search02(productId);
+					String number = String.valueOf(product.getNumber());
+					while(number.length() < 3) {
+						number = "0" + number;
+					}
+					String newProductId = mangaId + number;
+					productDAO.update02(product, newProductId);
+
+					MangaDAO mangaDAO = new MangaDAO();
+					// 最新の単行本の画像をマンガタイトルの画像に変更
+					mangaDAO.update04(mangaId, productDAO.search04(mangaId));
+					session.setAttribute("adminManga", mangaDAO.search03(mangaId));
+					session.setAttribute("adminProduct", productDAO.search02(newProductId));
+					session.setAttribute("productManagementMessage", Message.I_W0005.replace("{0}",newProductId));
+
+					// 表示するマンガタイトルリスト、商品リストを削除後の状態に更新
+					String title = (String) session.getAttribute("adminSearchTitle");
+					List<Manga> mangaList = mangaDAO.search04(title); 
+					List<Product> productList = productDAO.search03(product.getMangaId());
+					session.setAttribute("adminMangaList", mangaList);
+					session.setAttribute("adminProductList", productList);
+				}
 			}
 			response.sendRedirect("/ShoppingSite/views/product-info.jsp");
 		} catch (Exception e) {


### PR DESCRIPTION
@git-fuji-hub 
feature/105ブランチにて案件5の試験で発見した故障の改修を行いました。

・script.js
　・画像ファイル選択時に発生させる処理に、画像プレビューのキャプションを変更する処理を追加　[250行]
・product-info.jsp
　・入力フォームの値を条件によって変更するよう変更　[63, 69, 75行]
　・画像プレビューのキャプションにID属性を追加　[83行]
　・セッション属性の削除処理を追加（更新失敗時に入力していた値を格納しているもの）[102-104行]
・Constant.java
　・新たなメッセージを追加　[42行目]
・ProductDAO.java
　・search05メソッド（引数になっているマンガIDと巻数を持つ商品の数を返す）を追加　[99-118行]
・ProductDelete.java
　・セットするセッション属性及び値となるメッセージを変更　[41行]
　・削除処理後に総巻数が０である場合、マンガタイトルの画像URLをNULLに変更する処理を行うよう変更。 [48-53行]
　・リダイレクト先を変更　[67行]
・ProductUpdate.java
　・更新前と巻数が変更されているかつ商品情報にその巻数である商品が存在する場合、更新処理 [55-94行]を行わずセッション属性に入力した値とメッセージを格納する処理を行うよう変更。 [46-52行]

ご確認のほどよろしくお願いいたします。